### PR TITLE
Revert "specifies 'module' scope for relevant pytest fixtures"

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -101,7 +101,7 @@ def web3():
     return Web3(provider)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def w3_strict_abi():
     w3 = Web3(EthereumTesterProvider())
     w3.enable_strict_bytes_type_checking()

--- a/newsfragments/1767.misc.rst
+++ b/newsfragments/1767.misc.rst
@@ -1,1 +1,0 @@
-Remove duplicate block_number_formatter method in favor of to_hex_if_integer method

--- a/tests/core/filtering/conftest.py
+++ b/tests/core/filtering/conftest.py
@@ -113,7 +113,7 @@ class LogFunctions:
     LogAddressNotIndexed = 17
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def emitter_event_ids():
     return LogFunctions
 
@@ -156,6 +156,6 @@ def return_filter(
     return contract.events[event_name].createFilter(**kwargs)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def create_filter(request):
     return functools.partial(return_filter)


### PR DESCRIPTION
### What was wrong?

Related to Issue #

### How was it fixed?

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
